### PR TITLE
fixing 5prime 3prime parameters for ``add_tags_to_adapters.py``

### DIFF
--- a/using_adapters.html
+++ b/using_adapters.html
@@ -60,8 +60,8 @@ tags to a single adapter.  The program is invoked as follows and output is sent
 to stdout:</p>
 <div class="highlight-bash"><div class="highlight"><pre>python add_tags_to_adapters.py <span class="se">\</span>
     --input<span class="o">=</span><span class="nb">test</span>-data/edit_metric_tags.conf
-    --5prime<span class="o">=</span>CAAGCAGAAGACGGCATACGAGA
-    --3prime<span class="o">=</span>TGACTGGAGTTC <span class="se">\</span>
+    --5-prime<span class="o">=</span>CAAGCAGAAGACGGCATACGAGA
+    --3-prime<span class="o">=</span>TGACTGGAGTTC <span class="se">\</span>
     --section<span class="o">=</span><span class="s1">&#39;5nt ed3&#39;</span>
 </pre></div>
 </div>
@@ -121,8 +121,8 @@ integrated tag sequence is converted to lower-case:</p>
 <p>To write results to an output file, you can just use redirection:</p>
 <div class="highlight-bash"><div class="highlight"><pre>python add_tags_to_adapters.py <span class="se">\</span>
         --input<span class="o">=</span><span class="nb">test</span>-data/edit_metric_tags.conf
-        --5prime<span class="o">=</span>CAAGCAGAAGACGGCATACGAGA
-        --3prime<span class="o">=</span>TGACTGGAGTTC <span class="se">\</span>
+        --5-prime<span class="o">=</span>CAAGCAGAAGACGGCATACGAGA
+        --3-prime<span class="o">=</span>TGACTGGAGTTC <span class="se">\</span>
         --section<span class="o">=</span><span class="s1">&#39;5nt ed3&#39;</span> &gt; my_output_file.txt
 </pre></div>
 </div>


### PR DESCRIPTION
In documentation pages, they should be 5-prime and 3-prime.
